### PR TITLE
fix incorrect double letter highlights

### DIFF
--- a/app/components/PlayBoard.tsx
+++ b/app/components/PlayBoard.tsx
@@ -98,8 +98,10 @@ const getBlockStyle = (
     ) {
       return `${baseBlockStyle} ${wrongPositionStyle}`; // present, but at wrong position (more than one appearance) - Yellow color
     }
+    const occurancesInCorrectWord = correctWord.split(letter).length - 1
+    const indicesToCheck = indicesInWholeWord.slice(0, occurancesInCorrectWord)
 
-    if (commonIndices.length === 0) {
+    if (commonIndices.length === 0 && indicesToCheck.includes(keyPosition)) {
       return `${baseBlockStyle} ${wrongPositionStyle}`; // present, but at wrong position - Yellow color
     }
 


### PR DESCRIPTION
![wordle](https://github.com/HashirHussain/wordle/assets/10737812/7dd6571d-c439-485e-96f9-0358ab771fb6)

This pull request fixes the issue in the above screenshot where the letter R is highlighted twice even though the correct word contains only one occurrence of the letter R. You can reproduce the issue by following the path in the image for any given word.